### PR TITLE
Update dependencies to avoid git+ssh errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
     "start": "node index.js 2>&1"
   },
   "dependencies": {
-    "falcor": "0.1.2",
-    "falcor-json-graph": "1.1.0",
-    "falcor-router": "^0.2.8",
+    "falcor": "~0.1.12",
+    "falcor-json-graph": "~1.1.5",
+    "falcor-router": "~0.2.9",
     "pouchdb": "~3.6.0",
-    "promise": "^7.0.3",
-    "rx": "2.5.3"
+    "promise": "^7.0.4",
+    "rx": "~2.5.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes https://github.com/Netflix/falcor-router-demo/issues/7

The currently referenced versions of `falcor` and `falcor-json-graph` use **git+ssh** in their respective package files, causing installation errors.  Updating those dependencies with minor version matching (~) allows `npm install` to complete without error.

This will ultimately also fix the install error in `falcor-express-demo` (https://github.com/Netflix/falcor-express-demo/issues/2)