### PR TITLE
Update pouchdb to work with node 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "falcor": "~0.1.12",
     "falcor-json-graph": "~1.1.5",
     "falcor-router": "~0.2.9",
-    "pouchdb": "3.6.0",
+    "pouchdb": "4.0.3",
     "promise": "7.0.3",
     "rx": "2.5.3"
   },


### PR DESCRIPTION
Using node 4.0.0 and was getting the following error: `leveldown not available (specify another backend using the 'db' option)`. Updating pouchdb from 3.6.0 to 4.0.3 seems to fix this.