### PR TITLE
chore: added leveldown as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "falcor-json-graph": "~1.1.5",
     "falcor-router": "~0.2.9",
     "pouchdb": "4.0.3",
+    "leveldown": "1.4.1",
     "promise": "7.0.3",
     "rx": "2.5.3"
   },


### PR DESCRIPTION
because pouchdb lists it only as an optional dependency